### PR TITLE
Cmd upgrade to argparse

### DIFF
--- a/hotrc/hotrc.py
+++ b/hotrc/hotrc.py
@@ -75,16 +75,13 @@ class HotRC(object):
             contents = rc.read()
         return contents
 
-    def remove_alias(self, key, value=None):
+    def remove_alias(self, key):
         """
         Remove an alias from the `.bashrc` file if it exists.
         """
 
         bashrc = self.read_bashrc().split('\n')
-        if value is None:
-            command = "alias "+str(key)+"="
-        else:
-            command = "alias "+str(key)+"=\""+str(value)+"\""
+        command = "alias "+str(key)+"="
         for line in bashrc:
             if command in line:
                 del bashrc[bashrc.index(line)]
@@ -160,11 +157,6 @@ def start(args=None, rcfile=None):
     remove_parser = subparsers.add_parser('remove')
     remove_parser.set_defaults(which='remove')
     remove_parser.add_argument('alias_key', type=str, help='Alias Key')
-    remove_parser.add_argument('-v',
-                               '--alias_value',
-                               type=str,
-                               default=None,
-                               help='Alias Value')
 
     list_parser = subparsers.add_parser('list')
     list_parser.set_defaults(which='list')
@@ -184,7 +176,7 @@ def start(args=None, rcfile=None):
         h.create_alias(parsed_args.alias_key, parsed_args.alias_value)
     # Case 2: Remove an old alias.
     elif parsed_args.which == 'remove':
-        h.remove_alias(parsed_args.alias_key, parsed_args.alias_value)
+        h.remove_alias(parsed_args.alias_key)
     # Case 3: List all defined aliases.
     elif parsed_args.which == 'list':
         print("\nAll Aliases")

--- a/hotrc/hotrc.py
+++ b/hotrc/hotrc.py
@@ -201,4 +201,4 @@ def start(args=None, rcfile=None):
 
 
 if __name__ == "__main__":
-    start(rcfile='/Users/will/.bashrc')
+    start()

--- a/hotrc/hotrc.py
+++ b/hotrc/hotrc.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import argparse
 import os
 import sys
 import subprocess
@@ -141,16 +142,58 @@ class HotRC(object):
             end = len(bashrc)
         return (start, end)
 
+def description():
+    """Description for command line interface"""
+    return ''
 
 def start(args=None, rcfile=None):
     """ Controls the command line interface for hotrc """
+
+    parser = argparse.ArgumentParser(description=description())
+    subparsers = parser.add_subparsers()
+
+    new_parser = subparsers.add_parser('new')
+    new_parser.set_defaults(which='new')
+    new_parser.add_argument('alias_key', type=str, help='Alias Key')
+    new_parser.add_argument('alias_value', type=str, help='Alias Value')
+
+    remove_parser = subparsers.add_parser('remove')
+    remove_parser.set_defaults(which='remove')
+    remove_parser.add_argument('alias_key', type=str, help='Alias Key')
+    remove_parser.add_argument('-v', '--alias_value', type=str, default=None, help='Alias Value')
+
+    list_parser = subparsers.add_parser('list')
+    list_parser.set_defaults(which='list')
+
+    reset_parser = subparsers.add_parser('reset')
+    reset_parser.set_defaults(which='reset')
+
+    parsed_args = parser.parse_args(args)
 
     if rcfile is not None:
         h = HotRC(bashrc=rcfile)
     else:
         h = HotRC()  # pragma: no cover
-    if args is None:
-        args = sys.argv[1:]  # pragma: no cover
+
+    if parsed_args.which == 'new':
+        h.create_alias(args.alias_key, args.alias_value)
+    elif parsed_args.which == 'remove':
+        h.remove_alias(args.alias_key, args.alias_value)
+    elif parsed_args.which == 'list':
+        print("\nAll Aliases")
+        print("Key\tValue")
+        print("===\t=====\n")
+        for key, value in h.ALIASES.items():  # pragma: no cover
+            s = key + '\t' + value      # pragma: no cover
+            print(s)
+        print('')
+    elif parsed_args.which == 'reset':
+        os.remove(os.path.dirname(__file__)+'/info')  # pragma: no cover
+        h.get_info()                    # pragma: no cover
+
+
+
+    """
     try:
         # Case 1: Create a new alias.
         if args[0] == 'new' or args[0] == 'add':
@@ -196,6 +239,7 @@ def start(args=None, rcfile=None):
                 \thotrc rm/remove [key] [(optional) value]\n\
                 \thotrc list\n\
                 \thotrc reset\n')
+    """
 
 
 if __name__ == "__main__":

--- a/hotrc/hotrc.py
+++ b/hotrc/hotrc.py
@@ -160,7 +160,11 @@ def start(args=None, rcfile=None):
     remove_parser = subparsers.add_parser('remove')
     remove_parser.set_defaults(which='remove')
     remove_parser.add_argument('alias_key', type=str, help='Alias Key')
-    remove_parser.add_argument('-v', '--alias_value', type=str, default=None, help='Alias Value')
+    remove_parser.add_argument('-v',
+                               '--alias_value',
+                               type=str,
+                               default=None,
+                               help='Alias Value')
 
     list_parser = subparsers.add_parser('list')
     list_parser.set_defaults(which='list')
@@ -175,10 +179,13 @@ def start(args=None, rcfile=None):
     else:
         h = HotRC()  # pragma: no cover
 
+    # Case 1: Create a new alias.
     if parsed_args.which == 'new':
-        h.create_alias(args.alias_key, args.alias_value)
+        h.create_alias(parsed_args.alias_key, parsed_args.alias_value)
+    # Case 2: Remove an old alias.
     elif parsed_args.which == 'remove':
-        h.remove_alias(args.alias_key, args.alias_value)
+        h.remove_alias(parsed_args.alias_key, parsed_args.alias_value)
+    # Case 3: List all defined aliases.
     elif parsed_args.which == 'list':
         print("\nAll Aliases")
         print("Key\tValue")
@@ -187,60 +194,11 @@ def start(args=None, rcfile=None):
             s = key + '\t' + value      # pragma: no cover
             print(s)
         print('')
+    # Case 4: Reset the bashrc file.
     elif parsed_args.which == 'reset':
         os.remove(os.path.dirname(__file__)+'/info')  # pragma: no cover
         h.get_info()                    # pragma: no cover
 
 
-
-    """
-    try:
-        # Case 1: Create a new alias.
-        if args[0] == 'new' or args[0] == 'add':
-            if len(args) == 3:
-                h.create_alias(args[1], args[2])
-            else:
-                key = str(input("Alias Key: "))
-                value = str(input("Alias Value: "))
-                h.create_alias(key, value)  # pragma: no cover
-
-        # Case 2: Remove an old alias.
-        elif args[0] == 'remove' or args[0] == 'rm':
-            if len(args) > 1:
-                try:
-                    h.remove_alias(args[1], args[2])
-                except IndexError as e:
-                    h.remove_alias(args[1])
-            else:
-                key = str(input("Alias Key: "))
-                value = str(input("Alias Value: "))
-                h.remove_alias(key, value)  # pragma: no cover
-
-        # Case 3: List all defined aliases.
-        elif args[0] == 'list':             # pragma: no cover
-            print("\nAll Aliases")
-            print("Key\tValue")
-            print("===\t=====\n")
-            for key, value in h.ALIASES.items():  # pragma: no cover
-                s = key + '\t' + value      # pragma: no cover
-                print(s)
-            print('')
-
-        # Case 4: Reset the bashrc file.
-        elif args[0] == 'reset':            # pragma: no cover
-            os.remove(os.path.dirname(__file__)+'/info')  # pragma: no cover
-            h.get_info()                    # pragma: no cover
-    # Case Default: User doesn't add arguments.
-    except IndexError as e:  # pragma: no cover
-        print('\nERROR: No Arguments.\n\
-                Please run with arguments.\n\
-                Accepted syntax:\n\
-                \n\thotrc new/add [key] [value]\n\
-                \thotrc rm/remove [key] [(optional) value]\n\
-                \thotrc list\n\
-                \thotrc reset\n')
-    """
-
-
 if __name__ == "__main__":
-    start()
+    start(rcfile='/Users/will/.bashrc')

--- a/hotrc/hotrc.py
+++ b/hotrc/hotrc.py
@@ -178,7 +178,7 @@ def start(args=None, rcfile=None):
     elif parsed_args.which == 'remove':
         h.remove_alias(parsed_args.alias_key)
     # Case 3: List all defined aliases.
-    elif parsed_args.which == 'list':
+    elif parsed_args.which == 'list': # pragma: no cover
         print("\nAll Aliases")
         print("Key\tValue")
         print("===\t=====\n")
@@ -187,7 +187,7 @@ def start(args=None, rcfile=None):
             print(s)
         print('')
     # Case 4: Reset the bashrc file.
-    elif parsed_args.which == 'reset':
+    elif parsed_args.which == 'reset': # pragma: no cover
         os.remove(os.path.dirname(__file__)+'/info')  # pragma: no cover
         h.get_info()                    # pragma: no cover
 

--- a/tests/test_hotrc.py
+++ b/tests/test_hotrc.py
@@ -109,7 +109,7 @@ class TestHotRC(TestCase):
         ''' Tests start method to ensure new
         alias is added
         '''
-        start(args=['add', 'foo', 'bar'], rcfile=self.hotrc.BASHRC)
+        start(args=['new', 'foo', 'bar'], rcfile=self.hotrc.BASHRC)
         with open(self.hotrc.BASHRC, 'r') as result:
             result = result.read()
             self.assertIn('foo', result)
@@ -117,14 +117,14 @@ class TestHotRC(TestCase):
 
     def test_start_remove(self):
         ''' Tests start method to ensure alias is removed '''
-        start(args=['add', 'foo', 'bar'], rcfile=self.hotrc.BASHRC)
-        start(args=['rm', 'foo', 'bar'], rcfile=self.hotrc.BASHRC)
+        start(args=['new', 'foo', 'bar'], rcfile=self.hotrc.BASHRC)
+        start(args=['remove', 'foo', '-v bar'], rcfile=self.hotrc.BASHRC)
         with open(self.hotrc.BASHRC, 'r') as result:
             result = result.read()
             self.assertNotIn('foo', result)
             self.assertNotIn('bar', result)
-        start(args=['add', 'foo', 'bar'], rcfile=self.hotrc.BASHRC)
-        start(args=['rm', 'foo'], rcfile=self.hotrc.BASHRC)
+        start(args=['new', 'foo', 'bar'], rcfile=self.hotrc.BASHRC)
+        start(args=['remove', 'foo'], rcfile=self.hotrc.BASHRC)
         with open(self.hotrc.BASHRC, 'r') as result:
             result = result.read()
             self.assertNotIn('foo', result)

--- a/tests/test_hotrc.py
+++ b/tests/test_hotrc.py
@@ -118,12 +118,6 @@ class TestHotRC(TestCase):
     def test_start_remove(self):
         ''' Tests start method to ensure alias is removed '''
         start(args=['new', 'foo', 'bar'], rcfile=self.hotrc.BASHRC)
-        start(args=['remove', 'foo', '-v bar'], rcfile=self.hotrc.BASHRC)
-        with open(self.hotrc.BASHRC, 'r') as result:
-            result = result.read()
-            self.assertNotIn('foo', result)
-            self.assertNotIn('bar', result)
-        start(args=['new', 'foo', 'bar'], rcfile=self.hotrc.BASHRC)
         start(args=['remove', 'foo'], rcfile=self.hotrc.BASHRC)
         with open(self.hotrc.BASHRC, 'r') as result:
             result = result.read()


### PR DESCRIPTION
Command line interface update suggestion. I implemented the command line interface with argparse using subparsers. It maintains the exact same functionality as before (minus the captive user interfaces) but adds extendable, standardized descriptions, help messages and error messages. Now supports `--help` and `-h` for base command and subparsers
